### PR TITLE
Update es6.typed.array-buffer.js

### DIFF
--- a/modules/es6.typed.array-buffer.js
+++ b/modules/es6.typed.array-buffer.js
@@ -32,12 +32,12 @@ $export($export.P + $export.U + $export.F * require('./_fails')(function () {
     if ($slice !== undefined && end === undefined) return $slice.call(anObject(this), start); // FF fix
     var len = anObject(this).byteLength;
     var first = toAbsoluteIndex(start, len);
-    var final = toAbsoluteIndex(end === undefined ? len : end, len);
-    var result = new (speciesConstructor(this, $ArrayBuffer))(toLength(final - first));
+    var fin = toAbsoluteIndex(end === undefined ? len : end, len);
+    var result = new (speciesConstructor(this, $ArrayBuffer))(toLength(fin - first));
     var viewS = new $DataView(this);
     var viewT = new $DataView(result);
     var index = 0;
-    while (first < final) {
+    while (first < fin) {
       viewT.setUint8(index++, viewS.getUint8(first++));
     } return result;
   }


### PR DESCRIPTION
Rename variable 'final' to 'fin'. Because 'final' is reserved word in javascript. And it breaks down 'yui compressor'.
Please find the list of reserved words in js:
https://www.w3schools.com/js/js_reserved.asp
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar